### PR TITLE
feat: run ask-audio through Qwen2.5 Omni 3B via llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,49 @@ ollama run qwen3:8b -p "Say hi in one short sentence."
 * First response may be slower due to model load; subsequent prompts are faster.
 
 ---
+
+### Local multimodal LLM for “Ask (audio)” with Qwen2.5-Omni 3B (llama.cpp)
+
+Run an open‑source audio+text model through `llama.cpp` so your recordings stay on your Mac.
+
+```bash
+# 1) Build llama.cpp server (Metal enabled on Apple Silicon)
+git clone https://github.com/ggml-org/llama.cpp.git
+cd llama.cpp
+cmake -B build -DGGML_METAL=on
+cmake --build build --target llama-server
+
+# 2) Download a Qwen2.5-Omni gguf model (~3B parameters)
+#    (open weights hosted by ggml-org, no token required)
+mkdir -p ~/models/qwen2_5omni && cd ~/models/qwen2_5omni
+curl -L \
+  -o Qwen2.5-Omni-3B-Q8_0.gguf \
+  https://huggingface.co/ggml-org/Qwen2.5-Omni-3B-GGUF/resolve/main/Qwen2.5-Omni-3B-Q8_0.gguf
+
+# 3) Run the server
+~/path/to/llama.cpp/build/bin/llama-server \
+  -m ~/models/qwen2_5omni/Qwen2.5-Omni-3B-Q8_0.gguf \
+  --alias qwen2.5-omni-3b --host 127.0.0.1 --port 8080
+```
+
+**Configure EchoLite → Settings → “Ask (audio)”**
+
+* **Model:** `qwen2.5-omni-3b`
+* **Base URL:** `http://localhost:8080`
+* **API Key Env:** (leave empty)
+* **Temperature:** 0.2 (or your preference)
+* **System instruction:** e.g. “You are an assistant that answers questions directly from audio content.”
+
+> The route converts the uploaded audio to a 16 kHz mono WAV and sends it along with your question to the running `llama.cpp` server, which performs transcription and reasoning.
+
+**Use it**
+
+* Go to the **Ask (audio)** tab → upload audio → type an instruction → **Ask**.
+* The server replies, and the response is streamed back to the UI.
+
+**Troubleshooting (Ask audio)**
+
+* Ensure `ffmpeg` is installed; it's used for audio conversion.
+* If the port `8080` is busy, run the server with `--port 8081` and update the Base URL accordingly.
+* If downloading the model fails, ensure the URL is correct and you have enough disk space.
+---

--- a/app/api/ask-audio/route.ts
+++ b/app/api/ask-audio/route.ts
@@ -1,6 +1,8 @@
-import { mockCompletion } from "@/lib/mock-llm";
-import { SAMPLE_TRANSCRIPT } from "@/lib/sample";
 import { loadModelConfig } from "@/lib/model-config";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { spawn } from "node:child_process";
 
 export const runtime = "nodejs";
 
@@ -11,39 +13,109 @@ export async function POST(req: Request) {
 
   if (!file) {
     return new Response(JSON.stringify({ error: "No audio uploaded" }), {
-      status: 400, headers: { "Content-Type": "application/json" }
+      status: 400,
+      headers: { "Content-Type": "application/json" }
     });
   }
   if (!instruction) {
     return new Response(JSON.stringify({ error: "Missing instruction" }), {
-      status: 400, headers: { "Content-Type": "application/json" }
+      status: 400,
+      headers: { "Content-Type": "application/json" }
     });
   }
 
   const cfg = await loadModelConfig();
+  const ask = cfg.askAudio;
   const composedInstruction =
-    (cfg.askAudio.systemPrompt ? cfg.askAudio.systemPrompt + "\n\n" : "") + instruction;
+    (ask.systemPrompt ? ask.systemPrompt + "\n\n" : "") + instruction;
+  const baseURL = (ask.baseURL || "http://localhost:8080").replace(/\/+$/, "");
+  const temperature = Number.isFinite(ask.temperature) ? ask.temperature : 0.2;
 
-  await new Promise(r => setTimeout(r, 250)); // simulate work
+  const tmpDir = path.join(os.tmpdir(), "echolite");
+  await fs.mkdir(tmpDir, { recursive: true });
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const inputPath = path.join(tmpDir, `${id}-in`);
+  const wavPath = path.join(tmpDir, `${id}.wav`);
 
-  const fullText = mockCompletion(composedInstruction, SAMPLE_TRANSCRIPT);
-  const chunks = chunkText(fullText, 28);
+  try {
+    // Save uploaded file
+    const buf = Buffer.from(await file.arrayBuffer());
+    await fs.writeFile(inputPath, buf);
 
-  const stream = new ReadableStream({
-    async start(controller) {
-      const enc = new TextEncoder();
-      for (const c of chunks) {
-        controller.enqueue(enc.encode(c));
-        await new Promise(r => setTimeout(r, 25));
-      }
-      controller.close();
+    // Convert to 16kHz mono WAV via ffmpeg
+    await run("ffmpeg", ["-y", "-i", inputPath, "-ac", "1", "-ar", "16000", wavPath]);
+
+    // Read converted WAV and encode as base64
+    const wav = await fs.readFile(wavPath);
+    const audioB64 = wav.toString("base64");
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (ask.apiKeyEnv && process.env[ask.apiKeyEnv]) {
+      headers["Authorization"] = `Bearer ${process.env[ask.apiKeyEnv]}`;
     }
-  });
 
-  return new Response(stream, {
-    status: 200,
-    headers: { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "no-store" }
-  });
+    const r = await fetch(`${baseURL}/v1/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: ask.model || "qwen2.5-omni-3b",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "input_audio", audio: { data: audioB64, format: "wav" } },
+              { type: "input_text", text: composedInstruction }
+            ]
+          }
+        ],
+        temperature
+      })
+    });
+
+    if (!r.ok) {
+      const detail = await safeText(r);
+      return new Response(JSON.stringify({ error: "LLM call failed", detail }), {
+        status: 502,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const json = await r.json();
+    const answer =
+      json?.choices?.[0]?.message?.content?.[0]?.text ??
+      json?.choices?.[0]?.message?.content ??
+      json?.choices?.[0]?.text ??
+      "";
+
+    const chunks = chunkText(String(answer), 28);
+    const stream = new ReadableStream({
+      async start(controller) {
+        const enc = new TextEncoder();
+        for (const c of chunks) {
+          controller.enqueue(enc.encode(c));
+          await new Promise(r => setTimeout(r, 20));
+        }
+        controller.close();
+      }
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store"
+      }
+    });
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return new Response(
+      JSON.stringify({ error: "Processing failed", detail }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  } finally {
+    try { await fs.unlink(inputPath); } catch {}
+    try { await fs.unlink(wavPath); } catch {}
+  }
 }
 
 export async function GET() {
@@ -54,4 +126,21 @@ function chunkText(s: string, n: number): string[] {
   const out: string[] = [];
   for (let i = 0; i < s.length; i += n) out.push(s.slice(i, i + n));
   return out;
+}
+
+function run(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "pipe" });
+    let stderr = "";
+    child.stderr.on("data", d => { stderr += d.toString(); });
+    child.on("error", reject);
+    child.on("close", code => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} exited with code ${code}\n${stderr}`));
+    });
+  });
+}
+
+async function safeText(r: Response) {
+  try { return await r.text(); } catch { return ""; }
 }

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -69,10 +69,11 @@ export async function POST(req: Request) {
       modelPath,
       language
     });
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
     return NextResponse.json({
       error: "Transcription failed",
-      detail: String(err?.message || err)
+      detail
     }, { status: 500 });
   } finally {
     // Best-effort cleanup (comment out if you want to inspect artifacts)

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -80,10 +80,10 @@ export default function SettingsPage() {
       <Card title="Transcribe (audio → text)">
         <Grid>
           <Select label="Engine" value={cfg.transcribe.engine}
-                  onChange={(v) => setCfg({ ...cfg, transcribe: { ...cfg.transcribe, engine: v as any } })}
+                  onChange={(v) => setCfg({ ...cfg, transcribe: { ...cfg.transcribe, engine: v as "whisper_cpp" | "openai_compatible" } })}
                   options={["whisper_cpp","openai_compatible"]} />
           <Select label="Response format" value={cfg.transcribe.responseFormat}
-                  onChange={(v) => setCfg({ ...cfg, transcribe: { ...cfg.transcribe, responseFormat: v as any } })}
+                  onChange={(v) => setCfg({ ...cfg, transcribe: { ...cfg.transcribe, responseFormat: v as "text" | "verbose_json" } })}
                   options={["text","verbose_json"]} />
         </Grid>
 

--- a/configs/echolite.models.json
+++ b/configs/echolite.models.json
@@ -1,8 +1,8 @@
 {
   "askAudio": {
-    "model": "mock-llm",
-    "baseURL": "http://localhost:4000/v1",
-    "apiKeyEnv": "LLM_API_KEY",
+    "model": "qwen2.5-omni-3b",
+    "baseURL": "http://localhost:8080",
+    "apiKeyEnv": "",
     "temperature": 0.2,
     "systemPrompt": "You are an assistant that answers questions directly from audio content."
   },


### PR DESCRIPTION
## Summary
- default ask-audio endpoint to Qwen2.5-Omni-3B and forward audio + text to a local `llama.cpp` server
- document how to download and serve the open Qwen2.5-Omni-3B GGUF weights
- update default model configuration for the ask-audio feature
- include troubleshooting and notes about running the local server

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f958338f48331b31ea7761785bfb0