### PR TITLE
feat: Add dark mode with toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,18 +5,16 @@
   --foreground: #171717;
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,9 @@
 }
 
 .dark {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: #111827;
+  --foreground: #d1d5db;
+  --accent: #8b5cf6;
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import NavTabs from "@/components/NavTabs";
 import { TranscriptProvider } from "./transcript-context";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 export const metadata: Metadata = {
   title: "EchoLite",
@@ -10,17 +11,19 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="bg-white text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100">
-        <TranscriptProvider>
-          <main className="mx-auto max-w-3xl px-4 py-8">
-            <header className="mb-4 flex items-center justify-between">
-              <h1 className="text-xl font-semibold tracking-tight">EchoLite</h1>
-            </header>
-            <NavTabs />
-            {children}
-          </main>
-        </TranscriptProvider>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <TranscriptProvider>
+            <main className="mx-auto max-w-3xl px-4 py-8">
+              <header className="mb-4 flex items-center justify-between">
+                <h1 className="text-xl font-semibold tracking-tight">EchoLite</h1>
+              </header>
+              <NavTabs />
+              {children}
+            </main>
+          </TranscriptProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -141,8 +141,8 @@ export default function SettingsPage() {
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border p-4 space-y-3">
-      <h2 className="font-medium">{title}</h2>
+    <div className="rounded-lg border p-4 space-y-3 dark:border-neutral-800">
+      <h2 className="font-medium dark:text-violet-400">{title}</h2>
       {children}
     </div>
   );
@@ -153,8 +153,8 @@ function Grid({ children }: { children: React.ReactNode }) {
 function Text(props: { label: string; value: string; onChange: (v: string) => void; inputMode?: "text"|"decimal" }) {
   return (
     <label className="block">
-      <span className="mb-1 block text-sm text-neutral-600">{props.label}</span>
-      <input className="w-full rounded border px-3 py-2"
+      <span className="mb-1 block text-sm text-neutral-600 dark:text-neutral-400">{props.label}</span>
+      <input className="w-full rounded border px-3 py-2 dark:bg-neutral-800 dark:border-neutral-700"
              inputMode={props.inputMode ?? "text"}
              value={props.value}
              onChange={e => props.onChange(e.target.value)} />
@@ -164,16 +164,16 @@ function Text(props: { label: string; value: string; onChange: (v: string) => vo
 function Area(props: { label: string; value: string; onChange: (v: string) => void }) {
   return (
     <label className="block">
-      <span className="mb-1 block text-sm text-neutral-600">{props.label}</span>
-      <textarea className="h-28 w-full rounded border px-3 py-2" value={props.value} onChange={e => props.onChange(e.target.value)} />
+      <span className="mb-1 block text-sm text-neutral-600 dark:text-neutral-400">{props.label}</span>
+      <textarea className="h-28 w-full rounded border px-3 py-2 dark:bg-neutral-800 dark:border-neutral-700" value={props.value} onChange={e => props.onChange(e.target.value)} />
     </label>
   );
 }
 function Select(props: { label: string; value: string; onChange: (v: string) => void; options: string[] }) {
   return (
     <label className="block">
-      <span className="mb-1 block text-sm text-neutral-600">{props.label}</span>
-      <select className="w-full rounded border px-3 py-2" value={props.value} onChange={e => props.onChange(e.target.value)}>
+      <span className="mb-1 block text-sm text-neutral-600 dark:text-neutral-400">{props.label}</span>
+      <select className="w-full rounded border px-3 py-2 dark:bg-neutral-800 dark:border-neutral-700" value={props.value} onChange={e => props.onChange(e.target.value)}>
         {props.options.map(o => <option key={o} value={o}>{o}</option>)}
       </select>
     </label>

--- a/components/NavTabs.tsx
+++ b/components/NavTabs.tsx
@@ -5,8 +5,11 @@ import { ThemeToggle } from "./ThemeToggle";
 
 function tab(active: boolean) {
   return [
-    "rounded-md px-3 py-1.5 border text-sm",
-    active ? "bg-neutral-100 dark:bg-neutral-900" : "hover:bg-neutral-50 dark:hover:bg-neutral-900"
+    "rounded-md px-3 py-1.5 border text-sm transition-colors",
+    "border-neutral-200 dark:border-neutral-800",
+    active
+      ? "bg-neutral-200 text-neutral-900 dark:bg-violet-600 dark:text-neutral-50"
+      : "text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
   ].join(" ");
 }
 

--- a/components/NavTabs.tsx
+++ b/components/NavTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ThemeToggle } from "./ThemeToggle";
 
 function tab(active: boolean) {
   return [
@@ -12,11 +13,14 @@ function tab(active: boolean) {
 export default function NavTabs() {
   const p = usePathname();
   return (
-    <nav className="mb-6 flex gap-2">
-      <Link href="/ask-audio" className={tab(p === "/ask-audio")}>Ask (audio)</Link>
-      <Link href="/transcribe" className={tab(p === "/transcribe")}>Transcribe</Link>
-      <Link href="/ask" className={tab(p === "/ask")}>Ask</Link>
-      <Link href="/settings" className={tab(p === "/settings")}>Settings</Link>
+    <nav className="mb-6 flex items-center justify-between">
+      <div className="flex gap-2">
+        <Link href="/ask-audio" className={tab(p === "/ask-audio")}>Ask (audio)</Link>
+        <Link href="/transcribe" className={tab(p === "/transcribe")}>Transcribe</Link>
+        <Link href="/ask" className={tab(p === "/ask")}>Ask</Link>
+        <Link href="/settings" className={tab(p === "/settings")}>Settings</Link>
+      </div>
+      <ThemeToggle />
     </nav>
   );
 }

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const { setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <button
+      className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-9 w-9"
+      onClick={() => setTheme(resolvedTheme === "light" ? "dark" : "light")}
+    >
+      <svg
+        className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+      </svg>
+      <svg
+        className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+      </svg>
+      <span className="sr-only">Toggle theme</span>
+    </button>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.4.6",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -4385,6 +4386,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.4.6",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.6"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
This commit introduces a dark mode feature to the application, along with a toggle button to allow users to switch between light and dark themes.

The implementation uses the `next-themes` library to manage theme state. A `ThemeProvider` component has been created to wrap the application and provide theme context. A new `ThemeToggle` component has been added to the navigation bar, which allows users to switch between light and dark modes.

The global CSS has been updated to support dark mode using a class-based approach, and the necessary dependencies have been added to `package.json`.